### PR TITLE
Trim whitespace from URI

### DIFF
--- a/github_repo_tag.rb
+++ b/github_repo_tag.rb
@@ -6,7 +6,7 @@ module Jekyll
     # use in this format: "user/repo"
     def initialize(tag_name, text, tokens)
       super
-      api_url = "https://api.github.com/repos/#{text}"
+      api_url = "https://api.github.com/repos/#{text.strip}"
       @repo = JSON.parse(open(api_url).read)
     end
 


### PR DESCRIPTION
If you form your Jekyll tag with whitespaces for formatting, those whitespaces are included in the `open` method call, which causes a `(URI::InvalidURIError)` error to be returned. Instead of removing the whitespace from the curly braces and produce something like: `{%github_repo_tag user/repo%}`, this commit removes the whitespace retroactively during the method call.